### PR TITLE
Allow empty & Retina fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
- /xcuserdata/
+xcuserdata/
 target/
 stamp.wiki
 *.xcworkspace
 Pods/
+.DS_Store

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
 platform :osx, '10.7'
 
-pod 'BRLOptionParser', '~> 0.3.0'
+pod 'BRLOptionParser', :git => 'git@github.com:stephencelis/BRLOptionParser.git', :commit => '65e29b0bcbd2c2022b0320126921e3e2f4eac830'
 pod 'HexColors', '~> 2.2.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,11 +3,21 @@ PODS:
   - HexColors (2.2.1)
 
 DEPENDENCIES:
-  - BRLOptionParser (~> 0.3.0)
+  - BRLOptionParser (from `git@github.com:stephencelis/BRLOptionParser.git`, commit `65e29b0bcbd2c2022b0320126921e3e2f4eac830`)
   - HexColors (~> 2.2.1)
 
+EXTERNAL SOURCES:
+  BRLOptionParser:
+    :commit: 65e29b0bcbd2c2022b0320126921e3e2f4eac830
+    :git: git@github.com:stephencelis/BRLOptionParser.git
+
+CHECKOUT OPTIONS:
+  BRLOptionParser:
+    :commit: 65e29b0bcbd2c2022b0320126921e3e2f4eac830
+    :git: git@github.com:stephencelis/BRLOptionParser.git
+
 SPEC CHECKSUMS:
-  BRLOptionParser: 896de9a82696b19f7dbb012b3830f365c45dc599
+  BRLOptionParser: e034c1be1a1515e9b22e752eacb8edd9abb0df4d
   HexColors: 01384d2bbe8dc4ffa43c3b4135db6e976952d153
 
 COCOAPODS: 0.35.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ DEPENDENCIES:
   - HexColors (~> 2.2.1)
 
 SPEC CHECKSUMS:
-  BRLOptionParser: e034c1be1a1515e9b22e752eacb8edd9abb0df4d
-  HexColors: 3a68db077cd6572a8f7d4aa1add284dd2436a934
+  BRLOptionParser: 896de9a82696b19f7dbb012b3830f365c45dc599
+  HexColors: 01384d2bbe8dc4ffa43c3b4135db6e976952d153
 
-COCOAPODS: 0.29.0
+COCOAPODS: 0.35.0

--- a/lib/Stamper.h
+++ b/lib/Stamper.h
@@ -2,6 +2,7 @@
 
 @property (nonatomic, readwrite) NSColor  *textColor;
 @property (nonatomic, readwrite) NSShadow *textShadow;
+@property (nonatomic, readwrite) BOOL allowEmpty;
 
 - (instancetype)init __attribute__((unavailable("init not available ")));
 - (instancetype)initWithFile:(NSString *)file;

--- a/lib/Stamper.m
+++ b/lib/Stamper.m
@@ -152,11 +152,29 @@
 
 - (NSBitmapImageRep *)bitmapRepresentation
 {
-    CGImageRef cgRef = [self.image CGImageForProposedRect:NULL
-                                                  context:nil
-                                                    hints:nil];
+    NSBitmapImageRep *bitmapImageRep = [[NSBitmapImageRep alloc] initWithBitmapDataPlanes:NULL
+                                                                               pixelsWide:(NSInteger)self.iconSize.width
+                                                                               pixelsHigh:(NSInteger)self.iconSize.height
+                                                                            bitsPerSample:8
+                                                                          samplesPerPixel:4
+                                                                                 hasAlpha:YES
+                                                                                 isPlanar:NO
+                                                                           colorSpaceName:NSDeviceRGBColorSpace
+                                                                              bytesPerRow:0
+                                                                             bitsPerPixel:0];
+    bitmapImageRep.size = self.iconSize;
 
-    return [[NSBitmapImageRep alloc] initWithCGImage:cgRef];
+    [NSGraphicsContext saveGraphicsState];
+    [NSGraphicsContext setCurrentContext:[NSGraphicsContext graphicsContextWithBitmapImageRep:bitmapImageRep]];
+
+    [self.image drawAtPoint:NSMakePoint(0, 0)
+                   fromRect:NSZeroRect
+                  operation:NSCompositeSourceOver
+                   fraction:1.0];
+
+    [NSGraphicsContext restoreGraphicsState];
+
+    return bitmapImageRep;
 }
 
 @end

--- a/lib/Stamper.m
+++ b/lib/Stamper.m
@@ -15,6 +15,7 @@
         _iconFile = file;
         _textShadow = [self defaultTextShadow];
         _textColor  = [NSColor whiteColor];
+        _allowEmpty = NO;
     }
     return self;
 }
@@ -56,7 +57,7 @@
         [self.image unlockFocus];
         return YES;
     } else {
-        return NO;
+        return self.allowEmpty;
     }
 }
 

--- a/stamp.xcodeproj/project.pbxproj
+++ b/stamp.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 		19A170BB229262F62F11F0F8 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = "___FULLUSERNAME___";
 				TargetAttributes = {
 					3DA56E88188827EE005BB08D = {
@@ -309,8 +310,6 @@
 			mainGroup = 19A17079BDB5CA25A2C6B72D;
 			productRefGroup = 19A1746FEA5F519D82AF44CE /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-			);
 			projectRoot = "";
 			targets = (
 				19A17B5D659587E4AB03CC23 /* stamp */,
@@ -507,6 +506,7 @@
 		3DA56E97188827EE005BB08D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",
@@ -522,6 +522,7 @@
 		3DA56E98188827EE005BB08D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",
@@ -541,6 +542,7 @@
 		3DC8C64F18882AEB00B72460 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "lib/lib-Prefix.pch";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -550,6 +552,7 @@
 		3DC8C65018882AEB00B72460 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "lib/lib-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (

--- a/stamp.xcodeproj/project.pbxproj
+++ b/stamp.xcodeproj/project.pbxproj
@@ -71,8 +71,9 @@
 		3DC8C63618882AEB00B72460 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		3DC8C63918882AEB00B72460 /* lib-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "lib-Prefix.pch"; sourceTree = "<group>"; };
 		3DC8C65C18882EA200B72460 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		98DD2EA52BD42DCE4C65434A /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		BA3E39D9D1CD4FFDBFEE8905 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		EF7124FFCF8F4D97BC50E052 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
+		DEB91419A6CE8BC902F425D3 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -116,7 +117,7 @@
 				19A1746FEA5F519D82AF44CE /* Products */,
 				19A17185927B2E4301D89DBA /* Frameworks */,
 				19A17173F5D08738F68883CD /* stamp */,
-				EF7124FFCF8F4D97BC50E052 /* Pods.xcconfig */,
+				B3CF7A8CB2AC701C743750DA /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -206,6 +207,15 @@
 				3DC8C63918882AEB00B72460 /* lib-Prefix.pch */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		B3CF7A8CB2AC701C743750DA /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				98DD2EA52BD42DCE4C65434A /* Pods.release.xcconfig */,
+				DEB91419A6CE8BC902F425D3 /* Pods.debug.xcconfig */,
+			);
+			name = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -349,7 +359,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -445,7 +455,7 @@
 		};
 		19A17550FB55E07C68579B7B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EF7124FFCF8F4D97BC50E052 /* Pods.xcconfig */;
+			baseConfigurationReference = DEB91419A6CE8BC902F425D3 /* Pods.debug.xcconfig */;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "stamp/stamp-Prefix.pch";
@@ -486,7 +496,7 @@
 		};
 		19A17D9C999D4D8F11B189E4 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EF7124FFCF8F4D97BC50E052 /* Pods.xcconfig */;
+			baseConfigurationReference = 98DD2EA52BD42DCE4C65434A /* Pods.release.xcconfig */;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "stamp/stamp-Prefix.pch";

--- a/stamp.xcodeproj/xcshareddata/xcschemes/lib.xcscheme
+++ b/stamp.xcodeproj/xcshareddata/xcschemes/lib.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0500"
+   LastUpgradeVersion = "0610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -39,6 +39,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3DC8C62F18882AEB00B72460"
+            BuildableName = "liblib.a"
+            BlueprintName = "lib"
+            ReferencedContainer = "container:stamp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/stamp.xcodeproj/xcshareddata/xcschemes/stamp.xcscheme
+++ b/stamp.xcodeproj/xcshareddata/xcschemes/stamp.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/stamp/main.m
+++ b/stamp/main.m
@@ -10,6 +10,7 @@ int main(int argc, const char * argv[])
         NSString *input = nil, *output = nil, *text = nil;
         __block NSColor *textColor = nil, *shadowColor = nil;
         BOOL noShadow;
+        BOOL allowEmpty = NO;
 
         [parser setBanner:@"usage: %s", argv[0]];
         [parser addOption:"input"  flag:0 description:@"input png file"  argument:&input];
@@ -33,6 +34,7 @@ int main(int argc, const char * argv[])
             shadowColor = [NSColor colorWithHexString:color alpha:1];
         }];
         [parser addOption:"no-shadow" flag:0 description:@"disable text shadow" value:&noShadow];
+        [parser addOption:"allow-empty" flag:0 description:@"ignore errors if text is too long" value:&allowEmpty];
 
         NSError *error = nil;
 
@@ -58,6 +60,7 @@ int main(int argc, const char * argv[])
         if (noShadow) {
             stamper.textShadow = nil;
         }
+        stamper.allowEmpty = allowEmpty;
 
         if (![stamper addText:text]) {
             fprintf(stderr, "error: text too long\n");

--- a/tests/StamperTest.m
+++ b/tests/StamperTest.m
@@ -31,6 +31,13 @@
     XCTAssertFalse([self.subject addText:@"Testing abcdefghijklmno qrstuvxyzdsa 123456789"]);
 }
 
+- (void)testAddingMoreTestWhichCanFitReturnsTrueIfAllowEmpty
+{
+    self.subject.allowEmpty = YES;
+
+    XCTAssertTrue([self.subject addText:@"Testing abcdefghijklmno qrstuvxyzdsa 123456789"]);
+}
+
 - (void)testSaveToShouldReturnTrueIfFailedSavedSuccessfully
 {
     XCTAssertTrue([self.subject saveTo:self.target], @"saveTo should return");

--- a/tests/StamperTest.m
+++ b/tests/StamperTest.m
@@ -3,6 +3,7 @@
 
 @interface StamperTest : XCTestCase
 @property Stamper *subject;
+@property NSString *initial;
 @property NSString *target;
 @end
 
@@ -11,8 +12,9 @@
 - (void)setUp
 {
     [super setUp];
-    self.subject = [[Stamper alloc] initWithFile:@"tests/icons/Icon.png"];
+    self.initial = @"tests/icons/Icon.png";
     self.target = [NSTemporaryDirectory() stringByAppendingPathComponent:@"icon.png"];
+    self.subject = [[Stamper alloc] initWithFile:self.initial];
 
     if ([[NSFileManager defaultManager] fileExistsAtPath:self.target]) {
         NSError *error;
@@ -47,6 +49,16 @@
 {
     [self.subject saveTo:self.target];
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:self.target], @"file does not exist");
+}
+
+- (void)testSavedFileSHouldHaveTheRightSize
+{
+    [self.subject saveTo:self.target];
+
+    NSImage *initialImage = [[NSImage alloc] initWithData:[NSData dataWithContentsOfFile:self.initial]];
+    NSImage *targetImage = [[NSImage alloc] initWithData:[NSData dataWithContentsOfFile:self.target]];
+
+    XCTAssertTrue(NSEqualSizes(targetImage.size, initialImage.size));
 }
 
 @end


### PR DESCRIPTION
Hey Jan!

Two main changes here:
1. We've been running into issues trying to stamp small icons, we'd like to add an `--allow-empty` option to just ignore failures if the text doesn't fit.
2. The integration tests were broken on my machine because of #1. So I fixed that too.

Had to switch `BRLOptionParser` to use the latest commit because it wouldn't compile on Yosemite.

Hope all is well :smiley: 
